### PR TITLE
Add links for 2021sp great works papers

### DIFF
--- a/content/great-works/2021sp.md
+++ b/content/great-works/2021sp.md
@@ -41,8 +41,10 @@ to figure out a good presentation style!
 
 #### Getting Papers
 
-Please search for the paper names on Google and use Cornell's [Passkey][] to
-get around paper paywalls.
+Paper titles are hyperlinked to PDFs available on the web. If a link is broken,
+open an issue at [the Github repo for this
+website](https://github.com/cornell-pl/pl.cs.cornell.edu/issues), or find
+a working link and make a pull request.
 
 
 | Date            | Topic       | Presenter & Mentor |
@@ -50,16 +52,16 @@ get around paper paywalls.
 | 02/09 | Organization and Paper Assignments | Rachit & Adrian |
 | 02/16 |<ul><li>A Theory of Type Polymorphism in Programming</li><li>FreezeML: Complete and Easy Type Inference for First-class Polymorphism</li></ul>| Michael |
 | 02/23 |<ul><li>Simplification by Cooperating Decision Procedures</li><li>Z3: An Efficient SMT Solver</li></ul>| Griffin & Eric |
-| 03/02 |<ul><li>Verification of Finite Concurrent Systems using Temporal Logic</li><li>IronFleet: proving safety and liveness of practical distributed systems</li></ul>| Haobin & Cooper |
-| 03/09 |<ul><li>Counterexample-Guided Abstraction Refinement</li><li>Counterexample-Guided Inductive Synthesis</li></ul>| Goktug & Rachit |
-| 03/16 |<ul><li>Recognizing Safety and Liveness</li><li>Enforceable Security Properties</li></ul>| Mark & Ryan |
-| 03/23 |<ul><li>Correctness of a Compiler for Arithmetic Expressions</li><li>The Next 700 Compiler Correctness Theorems</li></ul>| Anshuman & Alexa |
-| 03/30 |<ul><li>An Efficient Implementation of Self</li><li>Formally Verified Speculation and Deoptimization in a JIT Compiler</li></ul>| Salil & Eric |
-| 04/06 |<ul><li>Linear Regions are All You Need</li><li>RustBelt: Securing the Foundations of Rust</li></ul>| Priya & Rolph |
-| 04/13 |<ul><li>Abstract Interpretation</li><li>An Abstract Domain for Certifying Neural Networks</li></ul>| Oliver & Michael |
-| 04/27 |<ul><li>Quickly Detecting Relevant Program Invariants</li><li>Leveraging Test Generation and Specification Mining</li></ul>| Ayaka & Eric |
-| 05/04 |<ul><li>GenProg: A Generic Method for Automatic Software Repair</li><li>Neuro-Symbolic Program Corrector for Introductory Programming Assignments</li></ul>| Wen-Ding & Alexa |
-| 05/11 |<ul><li>FastTrack: Efficient and Precise Dynamic Race Detection</li><li>Data Race Detection on Compressed Traces</li></ul>| Luke & Drew |
+| 03/02 |<ul><li><a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.92.9102&rep=rep1&type=pdf">Automatic Verification of Finite-State Concurrent Systems Using Temporal Logic Specifications</a></li><li><a href="https://www.microsoft.com/en-us/research/wp-content/uploads/2017/06/ironfleet-cacm.pdf">IronFleet: proving safety and liveness of practical distributed systems</a></li></ul>| Haobin & Cooper |
+| 03/09 |<ul><li><a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.19.407&rep=rep1&type=pdf">Counterexample-Guided Abstraction Refinement</a></li><li><a href="https://link.springer.com/content/pdf/10.1007%2F978-3-319-96145-3_15.pdf">Counterexample-Guided Inductive Synthesis Modulo Theories</a></li></ul>| Goktug & Rachit |
+| 03/16 |<ul><li><a href="https://www.cs.cornell.edu/fbs/publications/RecSafeLive.pdf">Recognizing Safety and Liveness</a></li><li><a href="https://www.cs.cornell.edu/fbs/publications/EnfSecPols.pdf">Enforceable Security Properties</a></li></ul>| Mark & Ryan |
+| 03/23 |<ul><li><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.76.7835&rep=rep1&type=pdf">Correctness of a Compiler for Arithmetic Expressions</a></li><li><a href="https://www.ccs.neu.edu/home/amal/papers/next700ccc.pdf">The Next 700 Compiler Correctness Theorems</a></li></ul>| Anshuman & Alexa |
+| 03/30 |<ul><li><a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.932.571&rep=rep1&type=pdf">An Efficient Implementation of Self</a></li><li><a href="https://dl.acm.org/doi/pdf/10.1145/3434327">Formally Verified Speculation and Deoptimization in a JIT Compiler</a></li></ul>| Salil & Eric |
+| 04/06 |<ul><li><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.60.5862&rep=rep1&type=pdf">Linear Regions are All You Need</a></li><li><a href="https://dl.acm.org/doi/pdf/10.1145/3158154">RustBelt: Securing the Foundations of Rust</a></li></ul>| Priya & Rolph |
+| 04/13 |<ul><li><a href="https://www.di.ens.fr/~cousot/COUSOTpapers/publications.www/CousotCousot-POPL-77-ACM-p238--252-1977.pdf">Abstract Interpretation</a></li><li><a href="https://files.sri.inf.ethz.ch/website/papers/DeepPoly.pdf">An Abstract Domain for Certifying Neural Networks</a></li></ul>| Oliver & Michael |
+| 04/27 |<ul><li><a href="https://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.41.5376&rep=rep1&type=pdf">Quickly Detecting Relevant Program Invariants</a></li><li><a href="https://core.ac.uk/download/pdf/208265756.pdf">Leveraging Test Generation and Specification Mining</a></li></ul>| Ayaka & Eric |
+| 05/04 |<ul><li><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.221.1148&rep=rep1&type=pdf">GenProg: A Generic Method for Automatic Software Repair</a></li><li><a href="https://rishabhmit.bitbucket.io/papers/icse18.pdf">Neuro-Symbolic Program Corrector for Introductory Programming Assignments</a></li></ul>| Wen-Ding & Alexa |
+| 05/11 |<ul><li><a href="http://citeseerx.ist.psu.edu/viewdoc/download?doi=10.1.1.148.2759&rep=rep1&type=pdf">FastTrack: Efficient and Precise Dynamic Race Detection</a></li><li><a href="https://dl.acm.org/doi/pdf/10.1145/3236024.3236025">Data Race Detection on Compressed Traces</a></li></ul>| Luke & Drew |
 
 ---
 


### PR DESCRIPTION
I was having some trouble finding papers. More bibliographic information would have solved this but it would probably be unreadable with the way the site layout looks, so I added some links. Let me know if I picked the wrong version of things--some of the papers have conference and journal versions with the same title. In those cases I tried to pick the conference version. There's also 2 titles that I fixed. 

1. Verification of Finite Concurrent Systems using Temporal Logic -> Automatic Verification of Finite-State Concurrent Systems Using Temporal Logic Specifications
2. Counterexample-Guided Inductive Synthesis -> Counterexample-Guided Inductive Synthesis Modulo Theories
