### PR TITLE
PLDG Spring 2024: Links for external speakers and Zoom room

### DIFF
--- a/content/pldg/2024sp.md
+++ b/content/pldg/2024sp.md
@@ -32,12 +32,12 @@ plan to present virtually.
 | Jan 31  | Cancelled                |                 |      |
 | Feb 7   | [Property-Directed Reachability as Abstract Interpretation in the Monotone Theory](https://dl.acm.org/doi/pdf/10.1145/3498676)  | Vaibhav Mehta      |  |
 | Feb 14  | TBA | Jialu Bao |  |
-| Feb 21  | TBA | Joe Tassarotti |      |
+| Feb 21  | TBA | [Joe Tassarotti](https://cs.nyu.edu/~jt4767/) |      |
 | Feb 28  | TBA | Suraaj K    |      |
 | Mar 6   | TBA | Silei Ren |      |
 | Mar 13  | TBA | TBA  |  |
 | Mar 20  | TBA | TBA  |  |
-| Mar 27  | TBA | Elaine Li |      |
+| Mar 27  | TBA | [Elaine Li](https://efl9013.github.io/) | Anshuman |
 | Apr 3   | Spring Break             |                 |      |
 | Apr 10  | TBA | TBA |      |
 | Apr 17  | TBA | Soos Garry |  |
@@ -46,10 +46,10 @@ plan to present virtually.
 | May 8   | TBA | Yulun Yao | |
 | May 15  | Additional slots TBD | | |
 
-Some of the links above need institutional affiliation to access the papers.
-Use [Cornell PassKey](https://www.library.cornell.edu/services/apps/passkey)
-to access them.
+When using the links above to access papers, you may be asked to prove institutional affiliation.
+Use [Cornell PassKey](https://www.library.cornell.edu/services/apps/passkey).
 
 [Archive](../)
 
 [join-pldg]: mailto:pldg-l-request@cornell.edu?subject=join
+[zoom]: https://cornell.zoom.us/j/96036354065?pwd=UGRyRXVaTjhxczFoK3Q1bjYzVkRodz09


### PR DESCRIPTION
The Zoom link was broken, so this PR fixes that. I also went ahead and linked to the websites of our two external speakers so far.